### PR TITLE
fix key errors in lists

### DIFF
--- a/src/components/StyledComponents.js
+++ b/src/components/StyledComponents.js
@@ -3,6 +3,8 @@ import styled, { keyframes } from "styled-components";
 const brightNavy = "#2b3173";
 const darkNavy = "#272c34";
 const highlighter = "#00e65d";
+const tenpx = "0.6rem";
+const eightpx = "0.5rem";
 const sansFont =
   '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif';
 
@@ -60,7 +62,7 @@ export const SubNavbar = styled.div`
 `;
 
 export const Highlighter = styled.span`
-  border-bottom: 7px solid ${highlighter};
+  border-bottom: ${eightpx} solid ${highlighter};
 `;
 
 const loadingAnimation = keyframes`
@@ -104,7 +106,7 @@ export const IconEl = styled.div`
   align-items: flex-start;
   width: auto;
   justify-content: flex-start;
-  padding-right: 0.5rem;
+  padding-right: ${eightpx};
   color: ${darkNavy};
 `;
 
@@ -131,12 +133,12 @@ export const CardBox = styled.div`
   border-bottom: 7px solid ${highlighter};
   width: 350px;
   height: auto;
-  padding: 0.5rem 0.5rem 1rem;
+  padding: ${eightpx} ${eightpx} 1rem;
   box-sizing: border-box;
 `;
 
 export const CardText = styled.div`
-  padding-left: 0.5rem;
+  padding-left: ${eightpx};
 `;
 
 export const UlWrapper = styled.div`
@@ -155,10 +157,14 @@ export const Ul = styled.div`
   flex-wrap: wrap;
 `;
 
+export const DisplayFlex = styled.div`
+  display: flex;
+`;
+
 export const Li = styled.p`
-  margin-right: 10px;
+  margin-right: ${tenpx};
   text-align: center;
-  margin: 0 10px 0 0;
+  margin: 0 ${tenpx} 0 0;
   display: flex;
   align-items: flex-end;
 `;

--- a/src/components/project_sorting.jsx
+++ b/src/components/project_sorting.jsx
@@ -7,6 +7,7 @@ import {
   UlWrapper,
   Ul,
   Li,
+  DisplayFlex,
 } from "./StyledComponents";
 
 export const ProjectSorting = ({ projectList, sorting }) => {
@@ -70,17 +71,17 @@ export const ProjectSorting = ({ projectList, sorting }) => {
               </Ul>
             </UlWrapper>
             <p>{proj.description}</p>
-            <UlWrapper key={proj.tech_stack.length}>
+            <UlWrapper key={proj.id + proj.tech_stack.length}>
               <Ul>
                 {proj.tech_stack.length === 1 ? (
                   <Li>{proj.tech_stack[0]}</Li>
                 ) : (
                   proj.tech_stack.map((lang, index) =>
                     proj.tech_stack.length - 1 !== index ? (
-                      <>
-                        <Li key={index}>{lang}</Li>
-                        <Li key={index + 10}>|</Li>
-                      </>
+                      <DisplayFlex key={index}>
+                        <Li>{lang}</Li>
+                        <Li>|</Li>
+                      </DisplayFlex>
                     ) : (
                       <Li key={index}>{lang}</Li>
                     )

--- a/src/components/tech_stack.jsx
+++ b/src/components/tech_stack.jsx
@@ -1,4 +1,4 @@
-import { FlexUl, Li } from "./StyledComponents";
+import { DisplayFlex, FlexUl, Li } from "./StyledComponents";
 
 const TechStack = () => {
   const stackList = require("../data/tech_stack.json");
@@ -7,10 +7,10 @@ const TechStack = () => {
       <FlexUl>
         {stackList.map((stack, index) =>
           index !== stackList.length - 1 ? (
-            <>
-              <Li key={index}>{stack}</Li>
-              <Li key={index}>|</Li>
-            </>
+            <DisplayFlex key={index}>
+              <Li>{stack}</Li>
+              <Li>|</Li>
+            </DisplayFlex>
           ) : (
             <Li key={index}>{stack}</Li>
           )


### PR DESCRIPTION
errors: 
- the lists of tech stacks in About and Projects pages
- `<></>`, which is the first child of looping a list needs key

solution:
- turn `<></>` into `<div></div>` and give `display: flex`
